### PR TITLE
Polish Punkt migration follow-ups

### DIFF
--- a/src/main/frontend/scripts/components/SearchItem.vue
+++ b/src/main/frontend/scripts/components/SearchItem.vue
@@ -6,12 +6,10 @@
           {{ item.type }}
         </div>
         <div class="search-list-item__date">
-          <span class="icon icon--calendar"></span>
           <time :datetime="item.date.iso">{{ item.date.pretty }}</time>
         </div>
         <div class="search-list-item__authors">
           <div class="search-list-item__author" v-for="(author, i) in item.authors" :key="i">
-            <span class="icon icon--user"></span>
             <a :href="author.url">{{ author.name }}</a>
           </div>
         </div>

--- a/src/main/frontend/styles/main.scss
+++ b/src/main/frontend/styles/main.scss
@@ -385,6 +385,23 @@ img {
   }
 }
 
+.paging {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.paging__list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.paging__item {
+  margin: 0;
+}
+
 .app-cookie-line {
   padding-top: 1em;
   z-index: 1;

--- a/src/main/frontend/styles/partials/_search-results.scss
+++ b/src/main/frontend/styles/partials/_search-results.scss
@@ -83,6 +83,7 @@
     flex-direction: row;
     font-size: 0.85em;
     align-items: center;
+    gap: 1rem;
     margin-bottom: 0.5em;
   }
 
@@ -113,6 +114,7 @@
   &__authors {
     display: flex;
     align-items: center;
+    gap: 0.375em;
   }
 
   &__text,

--- a/src/main/resources/site/snippets/content-blocks.html
+++ b/src/main/resources/site/snippets/content-blocks.html
@@ -94,7 +94,7 @@
 <!-- /* Videos */ -->
 <div data-th-fragment="ctbVideos" data-th-remove="tag">
   <div
-    class="pkt-cell labs-prose"
+    class="pkt-cell"
     data-th-classappend="${block.isFullWidth} ? 'pkt-cell--span12' : 'labs-article-col'"
   >
     <div data-th-replace="block-videos.html(data=${block.ctbVideos})" data-th-remove="tag"></div>
@@ -106,7 +106,7 @@
 <!-- /* Links */ -->
 <div data-th-fragment="ctbLinks" data-th-remove="tag">
   <div
-    class="pkt-cell labs-prose"
+    class="pkt-cell"
     data-th-classappend="${block.isFullWidth} ? 'pkt-cell--span12' : 'labs-article-col'"
   >
     <div data-th-replace="block-links.html(data=${block.ctbLinks})" data-th-remove="tag"></div>
@@ -118,7 +118,7 @@
 <!-- /* Collection */ -->
 <div data-th-fragment="ctbCollection" data-th-remove="tag">
   <div
-    class="pkt-cell labs-prose"
+    class="pkt-cell"
     data-th-classappend="${block.isFullWidth} ? 'pkt-cell--span12' : 'labs-article-col'"
   >
     <div data-th-replace="block-links.html(data=${block.ctbCollection})" data-th-remove="tag"></div>

--- a/src/main/resources/site/snippets/paging.html
+++ b/src/main/resources/site/snippets/paging.html
@@ -1,14 +1,14 @@
-<div data-th-fragment="paging" data-th-if="${paging}" data-th-object="${paging}" class="paging pkt-container">
-  <ol class="pkt-grid paging__list">
-    <li data-th-if="*{prev}" class="pkt-cell paging__item">
+<div data-th-fragment="paging" data-th-if="${paging}" data-th-object="${paging}" class="paging">
+  <ol class="paging__list">
+    <li data-th-if="*{prev}" class="paging__item">
       <a data-th-href="*{prev}">
         [[${portal.localize({'_key=txt.previousPage'})}]]
       </a>
     </li>
-    <li data-th-if="*{currentPage && totalPages}" class="pkt-cell paging__item">
+    <li data-th-if="*{currentPage && totalPages}" class="paging__item">
       [[*{currentPage}]] / [[*{totalPages}]]
     </li>
-    <li data-th-if="*{next}" class="pkt-cell paging__item">
+    <li data-th-if="*{next}" class="paging__item">
       <a data-th-href="*{next}">
         [[${portal.localize({'_key=txt.nextPage'})}]]
       </a>


### PR DESCRIPTION
## Summary

- Drop `labs-prose` from `ctbLinks`, `ctbCollection` and `ctbVideos` content-block wrappers. The prose rules (disc bullets on `ul`, `h3` at 1.5em) were overriding the block-links component's own icons and `pkt-txt-18-medium` title size.
- Rewrite the paging snippet from `.pkt-grid`/`.pkt-cell` (which fell back to 1-column auto-placement) to a plain centered flex list, matching Bulma's `columns is-centered` behaviour.
- Give search-result metadata explicit flex `gap` between header sections and between icon/text within each, so tag, date and author info isn't crammed together.
- Remove the small calendar and user icons next to date and author in search results (deemed superfluous).

## Test plan

- [ ] Theme article with `ctbLinks` (e.g. `/tema/apen-by/dette-er-oslonokkelen/slik-far-du-oslonokkelen-i-ditt-lokale`): chevrons show, no disc bullets, titles at the normal `.pkt-txt-18-medium` size
- [ ] `/artikler` paging is horizontally centered under the article grid with breathing room
- [ ] `/sok?q=<term>` results have visible gap between tag/date/authors and no leftover calendar/user icons